### PR TITLE
Fixes #43 - recv_multipart returns cell array

### DIFF
--- a/lib/+zmq/@Socket/recv_multipart.m
+++ b/lib/+zmq/@Socket/recv_multipart.m
@@ -1,13 +1,13 @@
 function message = recv_multipart(obj, varargin)
     [buffLen, options] = obj.normalize_msg_options(varargin{:});
 
-    message = [];
+    message = {};
 
     keepReceiving = 1;
 
     while keepReceiving > 0
         part = obj.recv(buffLen, options{:});
-        message = [message part];
+        message = [message {part}];
         keepReceiving = obj.get('rcvmore');
     end
 end


### PR DESCRIPTION
If message is a cell array then the parts are easily distinguished.